### PR TITLE
Update link in golang-demo.md to new ATD blog

### DIFF
--- a/rest-apis/learn/examples/golang-demo.md
+++ b/rest-apis/learn/examples/golang-demo.md
@@ -12,4 +12,4 @@ In August 2016, our friends at [AllTheDucks](https://www.alltheducks.com) presen
 
 Following DevCon ANZ, the Ducks were kind enough to open source their project and write a blog to help developers learn the Golang REST Application they wrote.
 
-The blog can be found [here](https://blog.alltheducks.com/post/go-rest).
+The blog can be found [here](https://www.alltheducks.com/blog/using-the-learn-rest-api-from-golang).


### PR DESCRIPTION
We've migrated our blog, which included a change in URL structure. We have set up redirects, but it's better to have the direct link.